### PR TITLE
fix: runtime ISR resilience — maxDuration 60s + throw on regen errors

### DIFF
--- a/pages/[pageId].tsx
+++ b/pages/[pageId].tsx
@@ -6,6 +6,12 @@ import { getSiteMap } from '@/lib/get-site-map'
 import { resolveNotionPage } from '@/lib/resolve-notion-page'
 import { type PageProps, type Params } from '@/lib/types'
 
+// Hobby plan caps serverless functions at 10s by default; raise to 60s
+// (Hobby max) so Notion's loadPageChunk has time on heavy pages.
+export const config = {
+  maxDuration: 60
+}
+
 export const getStaticProps: GetStaticProps<PageProps, Params> = async (
   context
 ) => {
@@ -14,14 +20,24 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
   try {
     const props = await resolveNotionPage(domain, rawPageId)
 
-    return { props, revalidate: 10 }
+    // Long revalidate window keeps Notion request volume low. ISR still
+    // serves the cached page instantly; regeneration happens in the
+    // background and never blocks visitors.
+    return { props, revalidate: 60 }
   } catch (err) {
     console.error('page error', domain, rawPageId, err)
 
-    // Soft-fail: with fallback: true + ISR, a transient Notion failure
-    // should not kill the whole production build. The page hydrates on
-    // first request via getStaticProps re-run.
-    return { notFound: true, revalidate: 60 }
+    // Build phase: soft-fail so one bad page doesn't kill the whole export.
+    // fallback: true + getStaticPaths still lists this slug; ISR will hydrate
+    // on first request when Notion responds.
+    if (process.env.NEXT_PHASE === 'phase-production-build') {
+      return { notFound: true, revalidate: 60 }
+    }
+
+    // Runtime ISR: throw to keep serving the last-known-good cached page.
+    // Returning notFound here would commit a 404 to the cache for the
+    // revalidate window, which is what visitors saw before this fix.
+    throw err
   }
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,18 +3,27 @@ import { NotionPage } from '@/components/NotionPage'
 import { domain } from '@/lib/config'
 import { resolveNotionPage } from '@/lib/resolve-notion-page'
 
+// Hobby plan caps serverless functions at 10s by default; raise to 60s.
+export const config = {
+  maxDuration: 60
+}
+
 export const getStaticProps = async () => {
   try {
     const props = await resolveNotionPage(domain)
 
-    return { props, revalidate: 10 }
+    return { props, revalidate: 60 }
   } catch (err) {
     console.error('page error', domain, err)
 
-    // Soft-fail: matches pages/[pageId].tsx. Notion 429s during build
-    // shouldn't kill the whole deploy. ISR rebuilds the page on first
-    // request when the rate-limit window clears.
-    return { notFound: true, revalidate: 30 }
+    // Build phase: soft-fail. fallback: true means home hydrates on first
+    // request when Notion responds.
+    if (process.env.NEXT_PHASE === 'phase-production-build') {
+      return { notFound: true, revalidate: 60 }
+    }
+
+    // Runtime ISR: throw to keep serving the last-known-good snapshot.
+    throw err
   }
 }
 


### PR DESCRIPTION
## Symptoms after PR #2 deployed

From production runtime logs on \`boklanov.com\` (May 3 19:14–19:20 UTC):

\`\`\`
GET /Bury-Me-Behind-the-Baseboard 404 Vercel Runtime Timeout Error: Task timed out after 10 seconds
GET /The-Ape-Star            404 Vercel Runtime Timeout Error
GET /roman-boklanov-english  404 Vercel Runtime Timeout Error
GET /                         404 Notion 429 Too Many Requests
\`\`\`

Build was green. Runtime was breaking on most slugs and visitors saw "Notion Page Not Found".

## Diagnosis

Two compounding problems:

1. **Hobby plan caps serverless functions at 10s** by default. Our \`ofetchOptions: { timeout: 30_000 }\` is moot — Vercel kills the function at 10s before retries can finish.
2. **Soft-fail to \`{ notFound: true }\`** during *runtime ISR regeneration* commits a 404 to the page cache for the revalidate window. Visitors then see "Notion Page Not Found" stuck for 30+ seconds. Wrong call for runtime — that pattern was originally added for build-phase resilience.

## Fix

Three layered changes in \`pages/[pageId].tsx\` and \`pages/index.tsx\`:

### 1. \`maxDuration: 60\` (Hobby plan max)

\`\`\`ts
export const config = {
  maxDuration: 60
}
\`\`\`

Now ofetch's 30s timeout actually has time to expire naturally instead of being killed by Vercel at 10s.

### 2. Phase-aware error handling

\`\`\`ts
} catch (err) {
  console.error('page error', domain, rawPageId, err)

  if (process.env.NEXT_PHASE === 'phase-production-build') {
    // Build phase: soft-fail. fallback: true means the page hydrates
    // on first request when Notion responds.
    return { notFound: true, revalidate: 60 }
  }

  // Runtime ISR: throw to keep serving the last-known-good cached page.
  throw err
}
\`\`\`

When \`getStaticProps\` throws during ISR regeneration, Next preserves the existing static snapshot. That's the stale-while-revalidate pattern we want — visitors keep seeing the last good version while the next regeneration retries Notion in the background.

### 3. \`revalidate: 60\` (was 10s / 30s)

Reduces background regeneration volume 6×. Fewer Notion calls per minute, fewer 429s.

## Test plan

- [x] \`pnpm test\` passes (lint + prettier)
- [ ] Vercel preview deploy passes (build still green — phase-aware soft-fail preserved)
- [ ] On preview URL, walk \`/\`, \`/Bury-Me-Behind-the-Baseboard\`, \`/The-Ape-Star\`, \`/roman-boklanov-english\`. After initial cache warm-up, all should serve <500ms.
- [ ] Trigger Notion 429 (e.g. wait 60s for revalidate, hit slug again) — page should still serve cached HTML, not 404.
- [ ] Vercel function logs should show \`maxDuration: 60\` reflected (functions running 30-50s instead of being killed at 10s).

## Trade-offs

- The first request to a slug after deploy still triggers a fallback build (5-15s wait for that visitor). Unchanged by this PR.
- Build still emits \`skipping page "..." — recordMap missing\` warnings for ~5-10 pages each deploy — those slugs hydrate via fallback later. That's the existing trade.
- A genuinely deleted Notion page (real 404) won't be detected at runtime — it'll just keep serving the stale snapshot until the next successful build prunes the slug from \`getStaticPaths\`. Acceptable.

## Follow-ups

- Optional: add Notion auth (\`NOTION_API_KEY\`) to raise the rate-limit ceiling significantly. Would eliminate most 429s.
- Optional: post-deploy cache-warming Vercel Cron hitting key URLs so first-visit cold-ISR doesn't surprise users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)