### PR TITLE
feat: R2 recordMap cache — fall back to snapshot on Notion 429

### DIFF
--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -15,6 +15,9 @@ import {
 import { getTweetsMap } from './get-tweets'
 import { notion } from './notion-api'
 import { getPreviewImageMap } from './preview-images'
+import { getR2Bytes, isR2Enabled, putR2Bytes, r2Key } from './r2'
+
+const RECORDMAP_PREFIX = process.env.R2_RECORDMAP_PREFIX ?? 'cache/recordmap/'
 
 const getNavigationLinkPages = pMemoize(
   async (): Promise<ExtendedRecordMap[]> => {
@@ -53,9 +56,33 @@ const ROBUST_FETCH_OPTIONS = {
 }
 
 export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
-  let recordMap = await notion.getPage(pageId, {
-    ofetchOptions: ROBUST_FETCH_OPTIONS
-  })
+  // R2 read-through cache: snapshot every successful recordMap; on Notion
+  // 429/timeout/error during runtime ISR regen, serve the snapshot so visitors
+  // never see a 404 just because Notion is rate-limiting us.
+  const cacheKey = r2Key(RECORDMAP_PREFIX, pageId, 'json')
+
+  let recordMap: ExtendedRecordMap
+  try {
+    recordMap = await notion.getPage(pageId, {
+      ofetchOptions: ROBUST_FETCH_OPTIONS
+    })
+  } catch (err: any) {
+    if (isR2Enabled) {
+      const cached = await getR2Bytes(cacheKey).catch((err_: any) => {
+        console.warn('recordmap-cache get failed', pageId, err_?.message)
+        return null
+      })
+      if (cached) {
+        console.warn(
+          'notion.getPage failed, serving R2 recordMap snapshot',
+          pageId,
+          err?.message
+        )
+        return JSON.parse(new TextDecoder().decode(cached)) as ExtendedRecordMap
+      }
+    }
+    throw err
+  }
 
   if (navigationStyle !== 'default') {
     // ensure that any pages linked to in the custom navigation header have
@@ -78,6 +105,20 @@ export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
   }
 
   await getTweetsMap(recordMap)
+
+  // Snapshot the fully-assembled recordMap (with merged nav, preview images,
+  // tweets) so the fallback path can return it as-is without re-fetching.
+  if (isR2Enabled) {
+    try {
+      await putR2Bytes(
+        cacheKey,
+        new TextEncoder().encode(JSON.stringify(recordMap)),
+        'application/json'
+      )
+    } catch (err: any) {
+      console.warn('recordmap-cache put failed', pageId, err?.message)
+    }
+  }
 
   return recordMap
 }


### PR DESCRIPTION
## Summary

- Adds R2 read-through cache around `lib/notion.ts:getPage`
- After every successful Notion fetch, snapshots the fully-assembled `recordMap` (with merged nav, preview images, tweets) to R2 under `cache/recordmap/`
- On Notion 429 / timeout / 5xx, serves the R2 snapshot so visitors never see a 404 just because Notion is rate-limiting

This is **Option A** from `PLAN_VERCEL_CUTOVER.md` — the missing piece after PRs #2–#6. Build resilience and 60s timeouts already shipped, but every uncached slug still 404'd whenever Notion 429'd. With this PR, the site stays up regardless of Notion's mood once the cache is warm.

## Why

Sequence on a cold deploy under Notion rate-limiting (current behavior):
1. Build skipped slug due to 429 → no static HTML
2. First visitor triggers \`getStaticProps\` → Notion 429 → throw → 404 rendered
3. ISR retries every 60s; Notion keeps 429-ing → 404 stays

After this PR, step 2 falls back to the R2 snapshot from a previous deploy.

## Implementation

- \`lib/notion.ts\` — wraps \`notion.getPage\` in try/catch; on success writes through to R2, on failure attempts R2 read and returns the cached recordMap as-is
- Reuses \`getR2Bytes\`, \`putR2Bytes\`, \`r2Key\` from \`lib/r2.ts\` (PR #4); no new deps
- Cache key: \`cache/recordmap/{sha256(pageId)}.json\`
- TTL: none — overwritten on next successful fetch
- Configurable prefix via \`R2_RECORDMAP_PREFIX\` env var (defaults to \`cache/recordmap/\`)

## Edge cases

- R2 disabled (no env vars) → behaves exactly as before, no fallback
- R2 GET error during fallback path → logs, throws original Notion error (renders error UI, not stale data masked as fresh)
- Cold deploy with empty R2 prefix → first build still must hit Notion successfully at least once per slug (build-phase soft-fail behavior unchanged)
- Home page recordMap is ~1 MB — fits comfortably in R2 PUT

## Test plan

- [ ] \`pnpm tsc --noEmit\` passes (verified locally)
- [ ] \`pnpm test:lint\` passes (verified locally)
- [ ] \`pnpm test:prettier\` passes (verified locally)
- [ ] Vercel preview deploys cleanly
- [ ] After preview deploy, R2 bucket shows \`cache/recordmap/*.json\` keys populated
- [ ] On production, hit a slug that was 404'ing → renders correctly
- [ ] Manually induce Notion failure (e.g., revoke key briefly) → existing pages still serve from R2 snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)