### PR TITLE
fix: build-phase soft-fail in pages — auth confirmed, but Notion still bursts 429

### DIFF
--- a/pages/[pageId].tsx
+++ b/pages/[pageId].tsx
@@ -18,8 +18,15 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
   } catch (err) {
     console.error('page error', domain, rawPageId, err)
 
-    // we don't want to publish the error version of this page, so
-    // let next.js know explicitly that incremental SSG failed
+    // Build phase: soft-fail so a Notion 429 during pnpm build doesn't kill
+    // the whole deploy. fallback: true + ISR will hydrate this slug on
+    // first visit, where Notion-cookie auth makes regen reliable.
+    if (process.env.NEXT_PHASE === 'phase-production-build') {
+      return { notFound: true, revalidate: 10 }
+    }
+
+    // Runtime: throw so we keep serving the last-known-good ISR snapshot
+    // instead of caching a 404 for the revalidate window.
     throw err
   }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,8 +11,15 @@ export const getStaticProps = async () => {
   } catch (err) {
     console.error('page error', domain, err)
 
-    // we don't want to publish the error version of this page, so
-    // let next.js know explicitly that incremental SSG failed
+    // Build phase: soft-fail so a Notion 429 during pnpm build doesn't kill
+    // the whole deploy. fallback: true + ISR will hydrate the home page on
+    // first visit, where Notion-cookie auth makes regen reliable.
+    if (process.env.NEXT_PHASE === 'phase-production-build') {
+      return { notFound: true, revalidate: 10 }
+    }
+
+    // Runtime: throw so we keep serving the last-known-good ISR snapshot
+    // instead of caching a 404 for the revalidate window.
     throw err
   }
 }


### PR DESCRIPTION
## What PR #9 confirmed

The build log proved the auth fix is working:

\`\`\`
[notion-api] auth: token_v2=present(len=537), active_user=present(len=36)
\`\`\`

Both env vars reach the runtime. So the rate-limit ceiling IS being raised. But Notion still 429s during the build's burst of \`getStaticProps\` calls — particularly on the home page, whose 1.08 MB recordMap notion-client splits into multiple concurrent \`loadPageChunk\` requests.

Auth alone isn't enough to make a 50+ slug build bulletproof. We need the build to be tolerant of the residual 429s and let ISR backfill at runtime.

## What this PR does

Restore the \`NEXT_PHASE === 'phase-production-build'\` branch in both \`pages/index.tsx\` and \`pages/[pageId].tsx\` — the exact same pattern that was in PR #5 before I reverted it for upstream alignment.

\`\`\`ts
catch (err) {
  // ...
  if (process.env.NEXT_PHASE === 'phase-production-build') {
    return { notFound: true, revalidate: 10 }
  }
  throw err
}
\`\`\`

- **At build time**: a Notion 429 returns \`notFound\` for that one page. The build continues. \`fallback: true\` in \`getStaticPaths\` means the slug still resolves; ISR will hydrate it on first visit.
- **At runtime**: still throws (upstream behavior). This avoids caching a 404 to the ISR window if regen fails — visitors keep seeing the last-known-good snapshot.

## Why it's the smallest acceptable deviation from upstream

Six lines in each file, gated on \`NEXT_PHASE\`. Runtime semantics identical to upstream. Build semantics differ only when Notion 429s, which on upstream wouldn't matter (much smaller / quieter sites). \`lib/notion.ts\` stays fully upstream.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm test:lint\` clean
- [x] \`pnpm test:prettier\` clean
- [ ] Build succeeds even with 429s in the log
- [ ] First-visit to a build-skipped slug renders correctly via ISR
- [ ] Home page renders within ~30s of first visit after deploy

## What to watch in the build log

- \`[notion-api] auth: ...\` should still show present (env vars are propagated to Production scope)
- Some \`page error\` warnings may appear for slugs that 429'd — that's fine, those will hydrate at runtime
- Build should complete with \"Generating static pages (X/53)\" finishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)