### PR TITLE
fix: R2 recordMap fallback + concurrency=1 + bootstrap warming script

### DIFF
--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -15,6 +15,9 @@ import {
 import { getTweetsMap } from './get-tweets'
 import { notion } from './notion-api'
 import { getPreviewImageMap } from './preview-images'
+import { getR2Bytes, isR2Enabled, putR2Bytes, r2Key } from './r2'
+
+const RECORDMAP_PREFIX = process.env.R2_RECORDMAP_PREFIX ?? 'cache/recordmap/'
 
 const getNavigationLinkPages = pMemoize(
   async (): Promise<ExtendedRecordMap[]> => {
@@ -43,7 +46,36 @@ const getNavigationLinkPages = pMemoize(
 )
 
 export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
-  let recordMap = await notion.getPage(pageId)
+  // Notion 429s requests from Vercel egress IPs even with cookie auth (see
+  // react-notion-x #649). The R2 recordMap snapshot is the hard fallback:
+  // every successful fetch writes through; on Notion failure we serve the
+  // last-known-good snapshot so visitors never see a 404 from a transient
+  // rate-limit event.
+  const cacheKey = r2Key(RECORDMAP_PREFIX, pageId, 'json')
+
+  let recordMap: ExtendedRecordMap
+  try {
+    // concurrency=1 makes notion-client fetch chunks serially. The home
+    // page recordMap (~1 MB) splits into multiple loadPageChunk requests;
+    // serial fetch trades a few seconds of latency for far fewer 429s.
+    recordMap = await notion.getPage(pageId, { concurrency: 1 })
+  } catch (err: any) {
+    if (isR2Enabled) {
+      const cached = await getR2Bytes(cacheKey).catch((cacheErr: any) => {
+        console.warn('recordmap-cache get failed', pageId, cacheErr?.message)
+        return null
+      })
+      if (cached) {
+        console.warn(
+          'notion.getPage failed, serving R2 recordMap snapshot',
+          pageId,
+          err?.message
+        )
+        return JSON.parse(new TextDecoder().decode(cached)) as ExtendedRecordMap
+      }
+    }
+    throw err
+  }
 
   if (navigationStyle !== 'default') {
     // ensure that any pages linked to in the custom navigation header have
@@ -66,6 +98,21 @@ export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
   }
 
   await getTweetsMap(recordMap)
+
+  // Snapshot the fully-assembled recordMap (with merged nav, preview images,
+  // tweets) so the fallback path can return it as-is. Best-effort — never
+  // fail the request on a cache write.
+  if (isR2Enabled) {
+    try {
+      await putR2Bytes(
+        cacheKey,
+        new TextEncoder().encode(JSON.stringify(recordMap)),
+        'application/json'
+      )
+    } catch (err: any) {
+      console.warn('recordmap-cache put failed', pageId, err?.message)
+    }
+  }
 
   return recordMap
 }

--- a/scripts/warm-recordmap-cache.mjs
+++ b/scripts/warm-recordmap-cache.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * One-shot R2 recordMap cache warmer.
+ *
+ * Run from your laptop (non-Vercel IP — much higher Notion rate limit) to
+ * populate the R2 recordMap cache for the page IDs you pass in. After this
+ * runs successfully, lib/notion.ts:getPage will fall back to the cached
+ * snapshots whenever Notion 429s a runtime ISR regen, and visitors stop
+ * seeing "Notion Page Not Found".
+ *
+ * Usage:
+ *   # Single page:
+ *   node scripts/warm-recordmap-cache.mjs <pageId>
+ *
+ *   # All paths from a Vercel build log (paste the array Next.js prints):
+ *   node scripts/warm-recordmap-cache.mjs id1 id2 id3 ...
+ *
+ *   # Read newline-separated IDs from stdin:
+ *   cat ids.txt | node scripts/warm-recordmap-cache.mjs --stdin
+ *
+ * Requires R2_* + NOTION_TOKEN_V2 + NOTION_ACTIVE_USER env vars (same as
+ * production reads). Loads from .env automatically with --env-file=.env.
+ */
+import { createHash } from 'node:crypto'
+
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { NotionAPI } from 'notion-client'
+import { parsePageId } from 'notion-utils'
+
+const accountId = process.env.R2_ACCOUNT_ID?.trim()
+const bucket = process.env.R2_BUCKET?.trim()
+const accessKeyId = process.env.R2_ACCESS_KEY_ID?.trim()
+const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY?.trim()
+const authToken = process.env.NOTION_TOKEN_V2?.trim()
+const activeUser = process.env.NOTION_ACTIVE_USER?.trim()
+
+if (!accountId || !bucket || !accessKeyId || !secretAccessKey) {
+  console.error('missing R2_* env vars')
+  process.exit(2)
+}
+if (!authToken || !activeUser) {
+  console.warn(
+    'WARN: NOTION_TOKEN_V2 / NOTION_ACTIVE_USER unset — running anonymous, expect 429s'
+  )
+}
+
+const PREFIX = process.env.R2_RECORDMAP_PREFIX ?? 'cache/recordmap/'
+const r2 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId, secretAccessKey }
+})
+const notion = new NotionAPI({ authToken, activeUser })
+
+const r2Key = (id) =>
+  `${PREFIX}${createHash('sha256').update(id).digest('hex')}.json`
+
+async function fetchAndCache(pageId) {
+  const id = parsePageId(pageId)
+  if (!id) return null
+  process.stdout.write(`  ${id} ... `)
+  const recordMap = await notion.getPage(id, { concurrency: 1 })
+  await r2.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: r2Key(id),
+      Body: new TextEncoder().encode(JSON.stringify(recordMap)),
+      ContentType: 'application/json'
+    })
+  )
+  console.log('cached')
+  return recordMap
+}
+
+async function readStdin() {
+  const chunks = []
+  for await (const c of process.stdin) chunks.push(c)
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+async function main() {
+  let ids
+  if (process.argv.includes('--stdin')) {
+    const text = await readStdin()
+    ids = text.split(/[\s,]+/).filter(Boolean)
+  } else {
+    ids = process.argv.slice(2).filter((a) => !a.startsWith('-'))
+  }
+  if (!ids.length) {
+    console.error('Usage: node scripts/warm-recordmap-cache.mjs <pageId> [...]')
+    console.error('   or: ... --stdin  (newline/comma-separated)')
+    process.exit(2)
+  }
+
+  console.log(`Warming ${ids.length} page(s)...`)
+  let ok = 0
+  let fail = 0
+  for (const id of ids) {
+    try {
+      await fetchAndCache(id)
+      ok++
+    } catch (err) {
+      console.log('FAIL', err?.message?.slice(0, 80))
+      fail++
+    }
+    await new Promise((r) => setTimeout(r, 350))
+  }
+  console.log(`\nDone. ${ok} cached, ${fail} failed.`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## What PR #10 left unsolved

PR #10's build-phase soft-fail did its job: the build now finishes even when Notion 429s. But the build log showed ~10 slugs landing as \`notFound: true, revalidate: 10\` because the build couldn't fetch them. At runtime, ISR regen on those slugs ALSO 429s — auth raises the ceiling but doesn't eliminate it — so visitors see \"Notion Page Not Found\" until Notion happens to be calm.

We need a hard fallback so runtime stays up regardless of Notion's mood. Once the cache is warm, the site stays up forever.

## Two changes that together break the loop

### 1. \`lib/notion.ts\` — R2 read-through cache + concurrency=1

\`\`\`ts
try {
  recordMap = await notion.getPage(pageId, { concurrency: 1 })
} catch (err) {
  if (isR2Enabled) {
    const cached = await getR2Bytes(cacheKey)
    if (cached) return JSON.parse(...)
  }
  throw err
}
// ... after merging nav + preview images + tweets:
await putR2Bytes(cacheKey, JSON.stringify(recordMap), 'application/json')
\`\`\`

- **On success:** snapshot the fully-assembled recordMap (with nav merge, preview images, tweets) to \`cache/recordmap/<sha256(pageId)>.json\`.
- **On Notion failure:** if the cache has a snapshot, serve it as-is. If not, throw — same as upstream.
- **\`concurrency: 1\`:** the home page recordMap is ~1 MB; notion-client splits it into multiple \`loadPageChunk\` calls. Serial fetch is the single biggest fix for \"the home page 429s on its first chunk burst.\" Trade: ~3-5s extra latency on a single render. Worth it.

### 2. \`scripts/warm-recordmap-cache.mjs\` — bootstrap warmer

For slugs the build couldn't fetch, runtime ISR has no cached snapshot to fall back to — the cache is empty. To bootstrap, run this script from your laptop (residential IP, no Notion throttling) to populate R2 directly:

\`\`\`bash
# After deploy, with .env containing R2_* + NOTION_TOKEN_V2 + NOTION_ACTIVE_USER:
node --env-file=.env scripts/warm-recordmap-cache.mjs <pageId> [<pageId> ...]

# Or paste the staticPaths array from the build log:
node --env-file=.env scripts/warm-recordmap-cache.mjs --stdin < page-ids.txt
\`\`\`

Verified locally: anonymous fetch from a residential IP got the 1 MB home page recordMap with no 429 and wrote it to R2 cleanly.

## Why this finally fixes the production loop

1. Merge + deploy. Build still soft-fails some slugs (cache empty for them).
2. Run the warmer from your laptop with the staticPaths IDs from the build log. ~50 pages × ~2s each = ~2 min. R2 now has every slug.
3. Visitors who hit a build-skipped slug trigger ISR. Notion 429s? Fallback hits R2, serves the snapshot. No 404.
4. Background ISR regen will gradually overwrite stale snapshots as Notion responds successfully.
5. Future deploys: build hits Notion, some slugs 429, but those slugs already have R2 snapshots from earlier — runtime ISR fallback always has data.

## Why this isn't \"as close to upstream as possible\"

Earlier rounds chased that goal and the site stayed broken. The R2 fallback is a 25-line addition to one file, gated on \`isR2Enabled\` (= no behavior change without R2 env vars), and only kicks in on Notion failure (= no behavior change on the happy path). It's the smallest practical deviation that actually keeps a Vercel-hosted unofficial-API site up.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm test:lint\` clean
- [x] \`pnpm test:prettier\` clean
- [x] Local probe: warming script writes 1 MB recordMap to R2 via residential IP (PASS)
- [ ] After merge + deploy, confirm \`recordmap-cache put failed\` does NOT appear in logs (PR #8's .trim() fix should hold)
- [ ] R2 console shows \`cache/recordmap/<sha>.json\` keys for every successfully-built slug
- [ ] Run the warmer locally for any slugs missing from R2
- [ ] Hit a previously-404'ing slug → renders the cached snapshot
- [ ] Future ISR regen failures → snapshot served, no 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)