### PR TITLE
fix: restore vercel.json maxDuration=60 (the 10s cap is killing cold ISR)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "functions": {
+    "pages/index.tsx": {
+      "maxDuration": 60
+    },
+    "pages/[pageId].tsx": {
+      "maxDuration": 60
+    },
+    "pages/api/social-image.tsx": {
+      "maxDuration": 60
+    }
+  }
+}


### PR DESCRIPTION
## Diagnosis from PR #11's production log

\`\`\`
GET 200 boklanov.com /
  notion.getPage failed, serving R2 recordMap snapshot d997b204-...
  notion page { isDev: false, title: 'Роман Бокланов', ... }

GET 404 boklanov.com /Bury-Me-Behind-the-Baseboard
  Vercel Runtime Timeout Error: Task timed out after 10 seconds
\`\`\`

Two key facts:

1. **The R2 fallback is working.** The home page rendered via cached snapshot when Notion 429'd. That fully validates PR #11's design.
2. **The remaining 404s aren't 429s anymore — they're function timeouts.** \`/Bury-Me-Behind-the-Baseboard\` had no R2 entry (build-skipped, never warmed), so \`getStaticProps\` had to do the full cold path: \`notion.getPage\` + preview-image generation + tweet fetching. That exceeds Vercel's default 10s function cap, the runtime kills the function, Next falls back to the previously-committed \`notFound\`, visitor sees 404.

## Fix

Restore \`vercel.json\` with \`maxDuration: 60\`. This file shipped in PR #6 and I deleted it in PR #9 under the wrong assumption that auth would keep runtime fast enough for the 10s default. It does for cache hits (~50ms), but not for cold-path renders.

The contents are byte-identical to PR #6. Three SSG/API routes get 60s instead of 10s on Hobby's cap.

## Why this finally completes the chain

After this PR + a one-time warming run:

| Path | Time | Outcome |
|---|---|---|
| Cache hit (R2 has snapshot) | ~50 ms | 200 instantly |
| Cache miss + Notion succeeds | 5-30 s (within 60s cap) | 200, populates cache |
| Cache miss + Notion 429s | <1 s | throws → Next serves last-known-good |
| Cache hit + Notion 429s on regen | ~50 ms | 200 from snapshot (the PR #11 fix) |

Every path has a path home. The only failure mode left is \"R2 empty + Notion 429s on first visit\" — which is what the warming script bootstraps.

## Test plan

- [x] \`pnpm test:lint\` clean
- [x] \`pnpm test:prettier\` clean
- [ ] Deploy → \`/Bury-Me-Behind-the-Baseboard\` renders (timeout no longer hits) OR throws cleanly to last-known-good
- [ ] Run \`scripts/warm-recordmap-cache.mjs\` locally with the build-skipped slug IDs from the PR #11 build log (about 9 of them)
- [ ] After warming, every slug renders from R2 cache regardless of Notion's mood

## Note on \"as close to upstream as possible\"

\`vercel.json\` is the only file outside upstream's surface. It's deployment infrastructure, not application code, and Vercel's docs explicitly recommend \`vercel.json\` over per-page \`config\` exports for SSG functions. \`lib/notion.ts\`, \`pages/index.tsx\`, \`pages/[pageId].tsx\` keep the upstream-aligned + minimal-deviation shape from PRs #9-#11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)