### PR TITLE
feat(warmer): --all flag walks every page reachable from root

### DIFF
--- a/scripts/warm-recordmap-cache.mjs
+++ b/scripts/warm-recordmap-cache.mjs
@@ -3,29 +3,32 @@
  * One-shot R2 recordMap cache warmer.
  *
  * Run from your laptop (non-Vercel IP — much higher Notion rate limit) to
- * populate the R2 recordMap cache for the page IDs you pass in. After this
- * runs successfully, lib/notion.ts:getPage will fall back to the cached
- * snapshots whenever Notion 429s a runtime ISR regen, and visitors stop
- * seeing "Notion Page Not Found".
+ * populate the R2 recordMap cache. After this runs successfully,
+ * lib/notion.ts:getPage will fall back to the cached snapshots whenever
+ * Notion 429s a runtime ISR regen, and visitors stop seeing
+ * "Notion Page Not Found".
  *
  * Usage:
- *   # Single page:
- *   node scripts/warm-recordmap-cache.mjs <pageId>
+ *   # Walk every page reachable from the root (recommended after deploy):
+ *   node --env-file=.env scripts/warm-recordmap-cache.mjs --all
  *
- *   # All paths from a Vercel build log (paste the array Next.js prints):
- *   node scripts/warm-recordmap-cache.mjs id1 id2 id3 ...
+ *   # Specific page IDs:
+ *   node --env-file=.env scripts/warm-recordmap-cache.mjs <pageId> [<pageId> ...]
  *
- *   # Read newline-separated IDs from stdin:
- *   cat ids.txt | node scripts/warm-recordmap-cache.mjs --stdin
+ *   # Read newline/comma-separated IDs from stdin:
+ *   cat ids.txt | node --env-file=.env scripts/warm-recordmap-cache.mjs --stdin
  *
  * Requires R2_* + NOTION_TOKEN_V2 + NOTION_ACTIVE_USER env vars (same as
- * production reads). Loads from .env automatically with --env-file=.env.
+ * production reads).
  */
 import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import { NotionAPI } from 'notion-client'
-import { parsePageId } from 'notion-utils'
+import { getAllPagesInSpace, parsePageId } from 'notion-utils'
 
 const accountId = process.env.R2_ACCOUNT_ID?.trim()
 const bucket = process.env.R2_BUCKET?.trim()
@@ -40,7 +43,7 @@ if (!accountId || !bucket || !accessKeyId || !secretAccessKey) {
 }
 if (!authToken || !activeUser) {
   console.warn(
-    'WARN: NOTION_TOKEN_V2 / NOTION_ACTIVE_USER unset — running anonymous, expect 429s'
+    'WARN: NOTION_TOKEN_V2 / NOTION_ACTIVE_USER unset — running anonymous'
   )
 }
 
@@ -55,19 +58,27 @@ const notion = new NotionAPI({ authToken, activeUser })
 const r2Key = (id) =>
   `${PREFIX}${createHash('sha256').update(id).digest('hex')}.json`
 
-async function fetchAndCache(pageId) {
-  const id = parsePageId(pageId)
-  if (!id) return null
-  process.stdout.write(`  ${id} ... `)
-  const recordMap = await notion.getPage(id, { concurrency: 1 })
+async function fetchPage(pageId) {
+  return notion.getPage(pageId, { concurrency: 1 })
+}
+
+async function cache(pageId, recordMap) {
   await r2.send(
     new PutObjectCommand({
       Bucket: bucket,
-      Key: r2Key(id),
+      Key: r2Key(pageId),
       Body: new TextEncoder().encode(JSON.stringify(recordMap)),
       ContentType: 'application/json'
     })
   )
+}
+
+async function fetchAndCache(pageId) {
+  const id = parsePageId(pageId)
+  if (!id) return null
+  process.stdout.write(`  ${id} ... `)
+  const recordMap = await fetchPage(id)
+  await cache(id, recordMap)
   console.log('cached')
   return recordMap
 }
@@ -78,20 +89,47 @@ async function readStdin() {
   return Buffer.concat(chunks).toString('utf8')
 }
 
-async function main() {
-  let ids
-  if (process.argv.includes('--stdin')) {
-    const text = await readStdin()
-    ids = text.split(/[\s,]+/).filter(Boolean)
-  } else {
-    ids = process.argv.slice(2).filter((a) => !a.startsWith('-'))
-  }
-  if (!ids.length) {
-    console.error('Usage: node scripts/warm-recordmap-cache.mjs <pageId> [...]')
-    console.error('   or: ... --stdin  (newline/comma-separated)')
-    process.exit(2)
-  }
+function readSiteRootId() {
+  // site.config.ts is TypeScript; we can't import it from .mjs without tsx.
+  // Parse rootNotionPageId out as a regex match — robust enough for a config file.
+  const here = dirname(fileURLToPath(import.meta.url))
+  const path = join(here, '..', 'site.config.ts')
+  const src = readFileSync(path, 'utf8')
+  const m = src.match(/rootNotionPageId:\s*['"]([0-9a-f]+)['"]/i)
+  if (!m) throw new Error('could not read rootNotionPageId from site.config.ts')
+  return m[1]
+}
 
+async function warmAll() {
+  const root = readSiteRootId()
+  console.log(`Walking from root ${root} (this can take a few minutes)...`)
+  // Same call shape as lib/get-site-map.ts; concurrency=1 keeps Notion happy.
+  const pageMap = await getAllPagesInSpace(root, undefined, fetchPage, {
+    concurrency: 1,
+    traverseCollections: true,
+    maxDepth: 1
+  })
+
+  const ids = Object.keys(pageMap).filter((id) => pageMap[id])
+  console.log(`Discovered ${ids.length} pages, caching to R2...`)
+
+  let ok = 0
+  let fail = 0
+  for (const id of ids) {
+    process.stdout.write(`  ${id} ... `)
+    try {
+      await cache(id, pageMap[id])
+      console.log('cached')
+      ok++
+    } catch (err) {
+      console.log('FAIL', err?.message?.slice(0, 80))
+      fail++
+    }
+  }
+  console.log(`\nDone. ${ok} cached, ${fail} failed.`)
+}
+
+async function warmExplicit(ids) {
   console.log(`Warming ${ids.length} page(s)...`)
   let ok = 0
   let fail = 0
@@ -106,6 +144,35 @@ async function main() {
     await new Promise((r) => setTimeout(r, 350))
   }
   console.log(`\nDone. ${ok} cached, ${fail} failed.`)
+}
+
+async function main() {
+  if (process.argv.includes('--all')) {
+    await warmAll()
+    return
+  }
+
+  let ids
+  if (process.argv.includes('--stdin')) {
+    const text = await readStdin()
+    ids = text.split(/[\s,]+/).filter(Boolean)
+  } else {
+    ids = process.argv.slice(2).filter((a) => !a.startsWith('-'))
+  }
+  if (!ids.length) {
+    console.error('Usage:')
+    console.error(
+      '  node scripts/warm-recordmap-cache.mjs --all            # walk from root'
+    )
+    console.error(
+      '  node scripts/warm-recordmap-cache.mjs <pageId> [...]   # explicit'
+    )
+    console.error(
+      '  ... --stdin    # newline/comma-separated IDs on stdin'
+    )
+    process.exit(2)
+  }
+  await warmExplicit(ids)
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Why

The previous warmer required passing every pageId by hand. That's brittle: miss one slug → it 404s in production. And there's no single place that lists all 58 pages — the build log's \`skipping page\` list only covers pages the build couldn't fetch *during static path enumeration*; pages that fell through to \"page error\" during the static export pass aren't in that list. So the manual approach has gaps.

## What

Add \`--all\` flag. It reads \`rootNotionPageId\` from \`site.config.ts\`, then calls \`notion-utils\`' \`getAllPagesInSpace\` (same function \`lib/get-site-map.ts\` uses at build time) to enumerate every reachable page, and caches each to R2.

\`\`\`bash
node --env-file=.env scripts/warm-recordmap-cache.mjs --all
\`\`\`

## Verified

Just ran it against production R2 from a residential IP:

\`\`\`
Walking from root d997b20454e24c9685624e4eb254935b...
Discovered 58 pages, caching to R2...
  d997b204-54e2-4c96-8562-4e4eb254935b ... cached
  ...
  ee2d7bea-1148-4e16-bcb0-3effc276a719 ... cached    # ← Bury-Me-Behind-the-Baseboard
  ...
Done. 58 cached, 0 failed.
\`\`\`

Note that \`ee2d7bea-...\` (the slug that was 404ing for you) is included — it was missing from the explicit list we tried earlier because it wasn't in the build's \`skipping page\` log.

## Path forward (do this now, even before merging this PR)

1. The cache is **already warmed** by the run I just did. Every slug has a snapshot in R2.
2. PR #12 (vercel.json with \`maxDuration: 60\`) is now on \`main\` — Vercel just redeployed.
3. Hit \`https://boklanov.com/Bury-Me-Behind-the-Baseboard\` now. With cache hit + 60s timeout, it should render. If Notion 429s on regen, the R2 snapshot serves instead.

## Why this finally completes the chain

After this PR + the warm I just ran:
- ✅ R2 has snapshots for every page (warmer)
- ✅ Auth works (PR #9, confirmed in logs)
- ✅ Build is tolerant of 429s (PR #10)
- ✅ Runtime regen falls back to R2 on 429 (PR #11)
- ✅ R2 PUT signature works (PR #8)
- ✅ Function timeout is 60s, not 10s (PR #12, just merged)

Future deploys: build may still skip pages on 429, but those slugs already have R2 snapshots — runtime ISR fallback always has data. Re-run \`--all\` whenever you add new pages or change page structure.

## Test plan

- [x] \`pnpm test:lint\` clean
- [x] \`pnpm test:prettier\` clean
- [x] \`--all\` walks from root and caches 58 pages (verified locally against prod R2)
- [x] \`ee2d7bea-...\` (Bury-Me-Behind-the-Baseboard) included in the walk
- [ ] Hit \`/Bury-Me-Behind-the-Baseboard\` — renders 200 (now that the cache is warm + maxDuration is 60s)
- [ ] Hit several other previously-broken slugs — also 200
- [ ] Watch logs: any \`notion.getPage failed, serving R2 recordMap snapshot\` entries are now invisible-to-visitor wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)