### PR TITLE
ci: nightly + post-deploy R2 cache warmer (non-blocking)

### DIFF
--- a/.github/workflows/warm-recordmap-cache.yml
+++ b/.github/workflows/warm-recordmap-cache.yml
@@ -1,0 +1,63 @@
+name: Warm Notion recordMap cache
+
+# Walks the entire space from rootNotionPageId and caches each page's
+# recordMap to R2. Production's lib/notion.ts:getPage falls back to these
+# snapshots whenever Notion 429s a runtime ISR regen — so a warm R2 means
+# visitors never see "Notion Page Not Found" even when Notion throttles
+# Vercel's egress IPs.
+#
+# Runs:
+#   - on demand (workflow_dispatch from the GitHub UI)
+#   - daily 03:00 UTC
+#   - after merges to main (assumed Notion content may have changed)
+#
+# Failure policy: NON-BLOCKING. continue-on-error is set so the run is
+# marked successful regardless. If GitHub Actions IPs end up being
+# rate-limited by Notion, the existing R2 cache stays in place — no
+# regression. Check the run logs to see the per-page outcome.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
+  push:
+    branches: [main]
+
+# Don't queue multiple warmers; one in flight is plenty.
+concurrency:
+  group: warm-recordmap-cache
+  cancel-in-progress: false
+
+jobs:
+  warm:
+    name: Walk root and cache to R2
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Warm cache (best-effort)
+        continue-on-error: true
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          NOTION_TOKEN_V2: ${{ secrets.NOTION_TOKEN_V2 }}
+          NOTION_ACTIVE_USER: ${{ secrets.NOTION_ACTIVE_USER }}
+        run: node scripts/warm-recordmap-cache.mjs --all
+
+      - name: Note on outcome
+        if: always()
+        run: |
+          echo "::notice::Warmer finished. See the previous step's log for per-page outcome."
+          echo "::notice::Failures here are non-blocking — existing R2 snapshots stay in place."


### PR DESCRIPTION
## Summary

Removes the need to run \`scripts/warm-recordmap-cache.mjs\` from your laptop. The workflow runs the same script with \`--all\` on three triggers:

- **Manual** (\`workflow_dispatch\`) — \"Run workflow\" button in the Actions tab
- **Daily** at 03:00 UTC (low-traffic window)
- **After every push to \`main\`** (Notion content might have changed)

Total job time ≈ 3 min: ~30s install, ~2 min warming 58 pages.

## Failure policy: NON-BLOCKING

\`continue-on-error: true\` is set on the warmer step. If GitHub Actions IPs hit Notion's 429 (the existing \`build.yml\` warns this happened in the past), the run still reports success and the existing R2 snapshots stay in place. The warmer's own loop already soft-fails per-page, so the worst case is \"0 cached, N failed\" with the previous cache untouched.

In other words: this can never make things worse than they were before the workflow ran.

## What you need to do once

Add repo secrets in **Settings → Secrets and variables → Actions**:

| Secret | Value |
|---|---|
| \`R2_ACCOUNT_ID\` | (same as Vercel) |
| \`R2_BUCKET\` | \`boklanov-content\` |
| \`R2_ACCESS_KEY_ID\` | (same as Vercel) |
| \`R2_SECRET_ACCESS_KEY\` | (same as Vercel — paste **without** trailing newline) |
| \`NOTION_TOKEN_V2\` | (same as Vercel — \`token_v2\` cookie) |
| \`NOTION_ACTIVE_USER\` | (same as Vercel — \`notion_user_id\` cookie) |

Then go to **Actions → Warm Notion recordMap cache → Run workflow** (manually) to confirm it works against your bucket. After one green run, the daily cron + post-deploy trigger take over.

## What the run logs will show

\`\`\`
Walking from root d997b20454e24c9685624e4eb254935b...
Discovered 58 pages, caching to R2...
  d997b204-... ... cached
  ...
Done. 58 cached, 0 failed.
\`\`\`

If GitHub IPs do get throttled, you'll see \`FAIL\` lines mixed in. That's fine — the cache stays at whatever was last successfully written (locally or via a prior run).

## Caveat to watch for

The pre-existing \`.github/workflows/build.yml\` removed \`pnpm build\` because GitHub Actions IPs were hitting Notion 429s. That comment predates the auth fix; with \`NOTION_TOKEN_V2\` + \`NOTION_ACTIVE_USER\` + \`concurrency: 1\` the warmer is gentler than \`pnpm build\` and should fare better. But if it doesn't pan out, the fallback is option 2 from earlier (Cloudflare Workers Cron) or just keep running it locally.

## Test plan

- [ ] Add the six secrets to the repo
- [ ] Click \"Run workflow\" manually — confirm it ends with \"Done. N cached, 0 failed.\"
- [ ] Wait for the next scheduled run (or push to main) — confirm it triggers automatically
- [ ] If it ever fails: confirm the run is marked successful anyway (non-blocking) and that the previous R2 snapshots still serve production

🤖 Generated with [Claude Code](https://claude.com/claude-code)